### PR TITLE
Finish operations for leaderEpoch-updated partitions up to point ZK exception occurs

### DIFF
--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -35,7 +35,7 @@ import kafka.server.QuotaFactory.QuotaManagers
 import kafka.server.checkpoints.{LazyOffsetCheckpoints, OffsetCheckpointFile, OffsetCheckpoints}
 import kafka.utils._
 import kafka.zk.KafkaZkClient
-import kafka.zookeeper.{ZooKeeperClientException, ZooKeeperClientTimeoutException}
+import kafka.zookeeper.ZooKeeperClientException
 import org.apache.kafka.common.{ElectionType, IsolationLevel, Node, TopicPartition}
 import org.apache.kafka.common.errors._
 import org.apache.kafka.common.internals.Topic
@@ -1494,20 +1494,23 @@ class ReplicaManager(val config: KafkaConfig,
             error(s"Error while making broker the follower for partition $partition with leader " +
               s"$newLeaderBrokerId in dir $dirOpt", e)
             responseMap.put(partition.topicPartition, Errors.KAFKA_STORAGE_ERROR)
-          case e: ZooKeeperClientTimeoutException =>
-            partitionsToMakeFollower.remove(partition)
-            stateChangeLogger.error(s"Skipped the become-follower state change with correlation id $correlationId from " +
-              s"epoch ${partition.getLeaderEpoch} epoch for partition ${partition.topicPartition} with leader $newLeaderBrokerId " +
-              s"because ZooKeeper client timeout exception occurred while making a $partition's follower through $zkClient.", e)
-            error(s"ZooKeeper client timeout exception occurred while making a $partition's follower for $zkClient.'", e)
-            throw e
           case e: ZooKeeperClientException =>
-            partitionsToMakeFollower.remove(partition)
-            stateChangeLogger.error(s"Because a ZooKeeper client exception occurred " +
-              s"skipped the become follower state change with correlation id $correlationId from " +
-              s"epoch ${partition.getLeaderEpoch} for partition ${partition.topicPartition} with leader $newLeaderBrokerId", e)
-            error(s"ZooKeeper client occurred while making a $partition's follower through $zkClient.'", e)
-            throw e
+            // Finish operations for leaderEpoch-updated partitions up to this point.
+            replicaFetcherManager.removeFetcherForPartitions(partitionsToMakeFollower.map(_.topicPartition))
+            partitionsToMakeFollower.foreach { partition =>
+              completeDelayedFetchOrProduceRequests(partition.topicPartition)
+            }
+            val makeFollowerPartitionsAndLeaderOffset = partitionsToMakeFollower.map { partition =>
+              val leader = metadataCache.getAliveBrokers.find(_.id == partition.leaderReplicaIdOpt.get).get
+                .brokerEndPoint(config.interBrokerListenerName)
+              val fetchOffset = partition.localLogOrException.highWatermark
+              partition.topicPartition -> InitialFetchState(leader, partition.getLeaderEpoch, fetchOffset)
+            }.toMap
+            replicaFetcherManager.addFetcherForPartitions(makeFollowerPartitionsAndLeaderOffset)
+            stateChangeLogger.info(s"Because a ZooKeeper client exception occurred, completed become follower " +
+              s"state change with correlation identifier $correlationId from epoch ${partition.getLeaderEpoch} only for " +
+              s"those leaderEpoch-updated partitions with leader $newLeaderBrokerId before ZooKeeper disconnect occurred.", e)
+            error(s"ZooKeeper client occurred while rendering a $partition's follower through $zkClient.'", e)
         }
       }
 


### PR DESCRIPTION
**`Finish operations for leaderEpoch-updated partitions up to this point.`**

1 - Remove fetchers for partitions whose leader epoch is updated. 
2 - Finish delayed fetch and produce requests for those same partitions
3 - Re-add fetchers for those same partitions.
4 - Don't throw exception, but rather log it as an error about this occurrence.